### PR TITLE
Create Buildroot location

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -1,0 +1,8 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+source "$BR2_EXTERNAL_EDGEHOG_PATH/package/edgehog-astarte-interface/Config.in"		
+source "$BR2_EXTERNAL_EDGEHOG_PATH/package/edgehog-device-runtime/Config.in"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
+<!---
+  Copyright 2022 SECO Mind Srl
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 # edgehog-buildroot-packages

--- a/configs/edgehog_device_runtime_defconfig
+++ b/configs/edgehog_device_runtime_defconfig
@@ -1,0 +1,7 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+BR2_FORTIFY_SOURCE_NONE=y

--- a/external.desc
+++ b/external.desc
@@ -1,0 +1,8 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: EDGEHOG
+desc: Edgehog package recipes

--- a/external.mk
+++ b/external.mk
@@ -1,0 +1,7 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+include $(sort $(wildcard $(BR2_EXTERNAL_EDGEHOG_PATH)/package/*/*.mk))

--- a/package/edgehog-astarte-interface/Config.in
+++ b/package/edgehog-astarte-interface/Config.in
@@ -1,0 +1,15 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config BR2_PACKAGE_EDGEHOG_ASTARTE_INTERFACE
+        bool "edgehog-astarte-interface"
+        depends on BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME
+        help
+          Edgehog Astarte Interfaces contains the set of interfaces
+          that define a common communication schema between Astarte
+          remote istance and Edgehog devices.
+
+          https://github.com/edgehog-device-manager/edgehog-astarte-interfaces

--- a/package/edgehog-astarte-interface/edgehog-astarte-interface.mk
+++ b/package/edgehog-astarte-interface/edgehog-astarte-interface.mk
@@ -1,0 +1,24 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+###############################################################################
+#
+# EDGEHOG_ASTARTE_INTERFACE
+#
+################################################################################
+
+EDGEHOG_ASTARTE_INTERFACE_VERSION = v0.5.2
+EDGEHOG_ASTARTE_INTERFACE_SITE = https://github.com/edgehog-device-manager/edgehog-astarte-interfaces
+EDGEHOG_ASTARTE_INTERFACE_SITE_METHOD = git
+EDGEHOG_ASTARTE_INTERFACE_LICENSE = Apache License 2.0
+EDGEHOG_ASTARTE_INTERFACE_LICENSE_FILES = COPYING
+
+define EDGEHOG_ASTARTE_INTERFACE_INSTALL_TARGET_CMDS
+	$(INSTALL) -d -m 0755 $(TARGET_DIR)/usr/share/edgehog-astarte-interfaces
+	$(INSTALL) -D -m 0644 $(@D)/*.json $(TARGET_DIR)/usr/share/edgehog-astarte-interfaces
+endef
+
+$(eval $(generic-package))

--- a/package/edgehog-device-runtime/Config.in
+++ b/package/edgehog-device-runtime/Config.in
@@ -9,6 +9,7 @@ config BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME
             depends on BR2_PACKAGE_HOST_RUSTC_TARGET_ARCH_SUPPORTS
             depends on BR2_PACKAGE_HAS_UDEV
             depends on BR2_PACKAGE_DBUS
+            depends on BR2_FORTIFY_SOURCE_NONE
             select BR2_PACKAGE_EDGEHOG_ASTARTE_INTERFACE
             select BR2_PACKAGE_UPOWER
             select BR2_PACKAGE_CA_CERTIFICATES

--- a/package/edgehog-device-runtime/Config.in
+++ b/package/edgehog-device-runtime/Config.in
@@ -1,0 +1,51 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME
+            bool "edgehog-device-runtime"
+            depends on BR2_PACKAGE_HOST_RUSTC_TARGET_ARCH_SUPPORTS
+            depends on BR2_PACKAGE_HAS_UDEV
+            depends on BR2_PACKAGE_DBUS
+            select BR2_PACKAGE_EDGEHOG_ASTARTE_INTERFACE
+            select BR2_PACKAGE_UPOWER
+            select BR2_PACKAGE_CA_CERTIFICATES
+            select BR2_PACKAGE_HOST_RUSTC
+            default y
+            help
+              This is a portable middleware written in Rust, that enables remote device management 
+              on Linux-based systems.
+
+              https://github.com/edgehog-device-manager/edgehog-device-runtime
+
+if BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME
+
+    config BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME_ASTARTE_REALM
+      string "Astarte realm"
+      default "test"
+      help
+            The realm to be used use in Astarte requests.
+
+    config BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME_ASTARTE_PAIRING_BASE_URL
+        string "Astarte pairing base URL"
+        default "http://localhost:4003"
+        help
+            The base URL to reach Astarte Pairing API.This should be the URL up to (and excluding) /v1.
+
+    config BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME_ASTARTE_PAIRING_JWT
+        string "Pairing JWT token"
+        default ""
+        help
+            JWT token to authorize device registration.
+
+            Can be obtained with ./generate-astarte-credentials -t pairing -p yourrealmkey.key
+
+    config BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME_ASTARTE_DEVICE_ID
+        string "Astarte Device ID"
+        default ""
+        help
+            Astarte identifies each device with a 128 bit Device ID which has to be unique within its Realm
+
+endif

--- a/package/edgehog-device-runtime/edgehog-config.toml
+++ b/package/edgehog-device-runtime/edgehog-config.toml
@@ -1,0 +1,18 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+device_id = ASTARTE_DEVICE_ID
+pairing_token = ASTARTE_PAIRING_JWT
+pairing_url = ASTARTE_PAIRING_BASE_URL
+realm = ASTARTE_REALM
+interfaces_directory = "/usr/share/edgehog-astarte-interfaces"
+store_directory = "/data/edgehog-device-runtime/"
+download_directory = "/upload/"
+
+[[telemetry_config]]
+interface_name= "io.edgehog.devicemanager.StorageUsage"
+enabled= false
+period= 0

--- a/package/edgehog-device-runtime/edgehog-device-runtime.mk
+++ b/package/edgehog-device-runtime/edgehog-device-runtime.mk
@@ -1,0 +1,50 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+###############################################################################
+#
+# EDGEHOG_DEVICE_RUNTIME
+#
+################################################################################
+
+EDGEHOG_DEVICE_RUNTIME_VERSION = main
+EDGEHOG_DEVICE_RUNTIME_SITE = https://github.com/edgehog-device-manager/edgehog-device-runtime
+EDGEHOG_DEVICE_RUNTIME_SITE_METHOD = git
+EDGEHOG_DEVICE_RUNTIME_LICENSE = Apache License 2.0
+EDGEHOG_DEVICE_RUNTIME_LICENSE_FILES = COPYING
+
+EDGEHOG_DEVICE_RUNTIME_CARGO_ENV = \
+HOST_CC="x86_64-linux-gnu-gcc" \
+TARGET_CC="$(HOST_DIR)/bin/aarch64-linux-gcc" \
+TARGET_AR="$(HOST_DIR)/bin/aarch64-linux-ar"
+
+EDGEHOG_DEVICE_RUNTIME_CARGO_BUILD_OPTS= \
+--features systemd
+
+EDGEHOG_DEVICE_RUNTIME_CONFIG_TOML_FILE= $(TARGET_DIR)/var/lib/edgehog-device-runtime/edgehog-config.toml
+
+define EDGEHOG_DEVICE_RUNTIME_INSTALL_INIT_SYSTEMD
+	$(INSTALL) -D -m 644 $(BR2_EXTERNAL_EDGEHOG_PATH)/package/edgehog-device-runtime/edgehog-device-runtime.service \
+		$(TARGET_DIR)/usr/lib/systemd/system/edgehog-device-runtime.service
+endef
+
+define EDGEHOG_DEVICE_RUNTIME_INSTALL_CONFIG_DIR
+	$(INSTALL) -d -m 0755 $(TARGET_DIR)/var/lib/edgehog-device-runtime
+	$(INSTALL) -D -m 644 $(BR2_EXTERNAL_EDGEHOG_PATH)/package/edgehog-device-runtime/edgehog-config.toml \
+		$(EDGEHOG_DEVICE_RUNTIME_CONFIG_TOML_FILE)
+	$(SED) 's/ASTARTE_DEVICE_ID/$(BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME_ASTARTE_DEVICE_ID)/' \
+			$(EDGEHOG_DEVICE_RUNTIME_CONFIG_TOML_FILE)
+	$(SED) 's/ASTARTE_PAIRING_JWT/$(BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME_ASTARTE_PAIRING_JWT)/' \
+			$(EDGEHOG_DEVICE_RUNTIME_CONFIG_TOML_FILE)
+	$(SED) 's|ASTARTE_PAIRING_BASE_URL|$(BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME_ASTARTE_PAIRING_BASE_URL)|' \
+			$(EDGEHOG_DEVICE_RUNTIME_CONFIG_TOML_FILE)
+	$(SED) 's/ASTARTE_REALM/$(BR2_PACKAGE_EDGEHOG_DEVICE_RUNTIME_ASTARTE_REALM)/' \
+			$(EDGEHOG_DEVICE_RUNTIME_CONFIG_TOML_FILE)
+endef
+
+EDGEHOG_DEVICE_RUNTIME_POST_INSTALL_TARGET_HOOKS += EDGEHOG_DEVICE_RUNTIME_INSTALL_CONFIG_DIR
+
+$(eval $(cargo-package))

--- a/package/edgehog-device-runtime/edgehog-device-runtime.service
+++ b/package/edgehog-device-runtime/edgehog-device-runtime.service
@@ -1,0 +1,18 @@
+#
+# Copyright 2022 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[Unit]
+Description=Edgehog Device Runtime daemon
+After=syslog.target network.target
+
+[Service]
+Type = simple
+Environment="RUST_LOG=debug"
+ExecStart=/usr/bin/edgehog-device-runtime -c /var/lib/edgehog-device-runtime/edgehog-config.toml
+Restart = on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The Buildroot location is outside of the tree. This mechanism allows to keep package recipes, board support and configuration files outside of the Buildroot tree, while still having them nicely integrated in the build logic.