### PR TITLE
feat(runtime): improve restart policy

### DIFF
--- a/package/edgehog-device-runtime/edgehog-device-runtime.service
+++ b/package/edgehog-device-runtime/edgehog-device-runtime.service
@@ -6,13 +6,18 @@
 
 [Unit]
 Description=Edgehog Device Runtime daemon
-After=syslog.target network.target
+After=syslog.target network-online.target remote-fs.target nss-lookup.target
+Wants=network-online.target
+# For development, keep restarting to wait for the platform to come online
+StartLimitIntervalSec=0
 
 [Service]
-Type = simple
+Type=simple
 Environment="RUST_LOG=debug"
 ExecStart=/usr/bin/edgehog-device-runtime -c /etc/edgehog/edgehog-device-runtime-config.toml
-Restart = on-failure
+Restart=on-failure
+# Avoid restarting too quickly
+RestartSec=2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Keep restarting the service without limit, but avoid restarting too quickly by waiting for 2 seconds before restarting. Also wait for the network to came online before starting the service.

We keep restarting since the local Astarte instance could not be deployed, or we are in the middle of a restart. The 2 second is a sensible time period to retry if the platform came online.

Closes #7