### PR TITLE
feat(message-hub): add astarte-message-hub package

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-source "$BR2_EXTERNAL_EDGEHOG_PATH/package/edgehog-astarte-interface/Config.in"		
+source "$BR2_EXTERNAL_EDGEHOG_PATH/package/edgehog-astarte-interface/Config.in"
 source "$BR2_EXTERNAL_EDGEHOG_PATH/package/edgehog-device-runtime/Config.in"
 source "$BR2_EXTERNAL_EDGEHOG_PATH/package/edgehog-device-hardwareId-service/Config.in"
+source "$BR2_EXTERNAL_EDGEHOG_PATH/package/astarte-message-hub/Config.in"

--- a/package/astarte-message-hub/Config.in
+++ b/package/astarte-message-hub/Config.in
@@ -1,0 +1,58 @@
+#
+# Copyright 2023 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config BR2_PACKAGE_ASTARTE_MESSAGE_HUB
+            bool "astarte-message-hub"
+            depends on BR2_PACKAGE_HOST_RUSTC_TARGET_ARCH_SUPPORTS
+            depends on BR2_PACKAGE_HOST_PROTOBUF_ARCH_SUPPORTS
+            depends on BR2_FORTIFY_SOURCE_NONE
+            select BR2_PACKAGE_CA_CERTIFICATES
+            select BR2_PACKAGE_HOST_RUSTC
+            select BR2_PACKAGE_HOST_PROTOBUF
+            default y
+            help
+              A central service that runs on (Linux) devices for collecting and delivering messages
+              from N apps using 1 MQTT connection to Astarte.
+
+              https://github.com/astarte-platform/astarte-message-hub
+
+if BR2_PACKAGE_ASTARTE_MESSAGE_HUB
+
+    config BR2_PACKAGE_ASTARTE_MESSAGE_HUB_ASTARTE_REALM
+      string "Astarte realm"
+      default "test"
+      help
+            The realm to be used use in Astarte requests.
+
+    config BR2_PACKAGE_ASTARTE_MESSAGE_HUB_ASTARTE_PAIRING_BASE_URL
+        string "Astarte pairing base URL"
+        default "http://localhost:4003"
+        help
+            The base URL to reach Astarte Pairing API.This should be the URL up to (and excluding)
+            /v1.
+
+    config BR2_PACKAGE_ASTARTE_MESSAGE_HUB_ASTARTE_PAIRING_JWT
+        string "Pairing JWT token"
+        default ""
+        help
+            JWT token to authorize device registration.
+
+            Can be obtained with ./generate-astarte-credentials -t pairing -p yourrealmkey.key
+
+    config BR2_PACKAGE_ASTARTE_MESSAGE_HUB_ASTARTE_DEVICE_ID
+        string "Astarte Device ID"
+        default ""
+        help
+            Astarte identifies each device with a 128 bit Device ID which has to be unique within
+            its Realm
+
+   config BR2_PACKAGE_ASTARTE_MESSAGE_HUB_GRPC_PORT
+      int "Astarte Message Hub gRPC port"
+      default 50051
+      range 1 65535
+      help
+            The port to be used for gRPC communication with the Nodes.
+endif

--- a/package/astarte-message-hub/astarte-message-hub.mk
+++ b/package/astarte-message-hub/astarte-message-hub.mk
@@ -1,0 +1,53 @@
+#
+# Copyright 2022-2023 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+###############################################################################
+#
+# ASTARTE_MESSAGE_HUB
+#
+################################################################################
+
+ASTARTE_MESSAGE_HUB_VERSION = v0.5.2
+ASTARTE_MESSAGE_HUB_SITE = https://github.com/astarte-platform/astarte-message-hub
+ASTARTE_MESSAGE_HUB_SITE_METHOD = git
+ASTARTE_MESSAGE_HUB_LICENSE = Apache License 2.0
+ASTARTE_MESSAGE_HUB_LICENSE_FILES = COPYING
+
+ASTARTE_MESSAGE_HUB_DEPENDENCIES = host-protobuf
+
+ASTARTE_MESSAGE_HUB_CARGO_ENV = \
+HOST_CC="x86_64-linux-gnu-gcc" \
+TARGET_CC="$(HOST_DIR)/bin/aarch64-linux-gcc" \
+TARGET_AR="$(HOST_DIR)/bin/aarch64-linux-ar"
+
+ASTARTE_MESSAGE_HUB_CARGO_BUILD_OPTS=
+
+ASTARTE_MESSAGE_HUB_CONFIG_TOML_FILE= $(TARGET_DIR)/etc/astarte/astarte-message-hub-config.toml
+
+define ASTARTE_MESSAGE_HUB_INSTALL_INIT_SYSTEMD
+	$(INSTALL) -D -m 644 $(BR2_EXTERNAL_EDGEHOG_PATH)/package/astarte-message-hub/astarte-message-hub.service \
+		$(TARGET_DIR)/usr/lib/systemd/system/astarte-message-hub.service
+endef
+
+define ASTARTE_MESSAGE_HUB_INSTALL_CONFIG_DIR
+	$(INSTALL) -d -m 0755 $(TARGET_DIR)/etc/astarte-message-hub/
+	$(INSTALL) -D -m 644 $(BR2_EXTERNAL_EDGEHOG_PATH)/package/astarte-message-hub/config.toml \
+		$(ASTARTE_MESSAGE_HUB_CONFIG_TOML_FILE)
+	$(SED) 's/ASTARTE_DEVICE_ID/$(BR2_PACKAGE_ASTARTE_MESSAGE_HUB_ASTARTE_DEVICE_ID)/' \
+			$(ASTARTE_MESSAGE_HUB_CONFIG_TOML_FILE)
+	$(SED) 's/ASTARTE_PAIRING_JWT/$(BR2_PACKAGE_ASTARTE_MESSAGE_HUB_ASTARTE_PAIRING_JWT)/' \
+			$(ASTARTE_MESSAGE_HUB_CONFIG_TOML_FILE)
+	$(SED) 's|ASTARTE_PAIRING_BASE_URL|$(BR2_PACKAGE_ASTARTE_MESSAGE_HUB_ASTARTE_PAIRING_BASE_URL)|' \
+			$(ASTARTE_MESSAGE_HUB_CONFIG_TOML_FILE)
+	$(SED) 's/ASTARTE_REALM/$(BR2_PACKAGE_ASTARTE_MESSAGE_HUB_ASTARTE_REALM)/' \
+			$(ASTARTE_MESSAGE_HUB_CONFIG_TOML_FILE)
+	$(SED) 's/ASTARTE_GRPC_SOCKET_PORT/$(BR2_PACKAGE_ASTARTE_MESSAGE_HUB_GRPC_PORT)/' \
+			$(ASTARTE_MESSAGE_HUB_CONFIG_TOML_FILE)
+endef
+
+ASTARTE_MESSAGE_HUB_POST_INSTALL_TARGET_HOOKS += ASTARTE_MESSAGE_HUB_INSTALL_CONFIG_DIR
+
+$(eval $(cargo-package))

--- a/package/astarte-message-hub/astarte-message-hub.service
+++ b/package/astarte-message-hub/astarte-message-hub.service
@@ -1,0 +1,23 @@
+#
+# Copyright 2022-2023 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[Unit]
+Description=Astarte Message Hub
+After=syslog.target network-online.target remote-fs.target nss-lookup.target
+Wants=network-online.target
+# For development, keep restarting to wait for the platform to come online
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Environment="RUST_LOG=debug"
+ExecStart=/usr/bin/astarte-message-hub -t /etc/astarte/astarte-message-hub-config.toml
+Restart=on-failure
+# Avoid restarting too quickly
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/package/astarte-message-hub/config.toml
+++ b/package/astarte-message-hub/config.toml
@@ -1,0 +1,12 @@
+#
+# Copyright 2022-2023 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+realm = ASTARTE_REALM
+device_id = ASTARTE_DEVICE_ID
+pairing_url = ASTARTE_PAIRING_BASE_URL
+pairing_token = ASTARTE_PAIRING_JWT
+grpc_socket_port = ASTARTE_GRPC_SOCKET_PORT
+
+store_directory = "/var/lib/edgehog-device-runtime/"


### PR DESCRIPTION
This will add the astarte-message-hub package to the buildroot.

Closes #9.